### PR TITLE
Reorder Locations Fix

### DIFF
--- a/omod/src/main/webapp/resources/js/view/editors.js
+++ b/omod/src/main/webapp/resources/js/view/editors.js
@@ -410,7 +410,7 @@ define(
 						for(i = 0; i < rootLocations.models.length; i++) {
 							var rootLoc = rootLocations.models[i];
 							
-							if(rootLoc !== null && rootLoc !== undefined) {
+							if(rootLoc !== null && rootLoc !== undefined && rootLoc.get("links") != null) {
 								var locationModel = cur.createLocationModel(rootLoc.get("display"), 
 										rootLoc.get("uuid"), rootLoc.get("links")[0].uri);
 								


### PR DESCRIPTION
Fix for LocationSelect element in the inventory module. The LocationSelect element was
crashing when it had to be reload a seccond time when there was an empty option in the list.